### PR TITLE
Fix TasksPage structure to resolve run-time errors

### DIFF
--- a/lib/features/tasks/ui/tasks_page.dart
+++ b/lib/features/tasks/ui/tasks_page.dart
@@ -1,26 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+
+import '../presentation/providers/task_provider.dart';
+
 class TasksPage extends StatefulWidget {
   const TasksPage({super.key});
-
-    @override
-    State<TasksPage> createState() => _TasksPageState();
-  }
-
-  class _TasksPageState extends State<TasksPage> {
-    @override
-    void initState() {
-      super.initState();
-      // Chargement de données de test
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final provider = context.read<TaskProvider>();
-        if (provider.allTasks.isEmpty) {
-          provider.loadTestData();
-        }
-      });
-    }
-
 
   @override
   State<TasksPage> createState() => _TasksPageState();


### PR DESCRIPTION
## Summary
- rewrite `TasksPage` to remove duplicate definitions and correctly import `TaskProvider`

## Testing
- `flutter analyze`
- `flutter test`
- `flutter run -d linux` *(fails: CMake cannot find CXX compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68c0287d386c83268cf2d86f092a4ffa